### PR TITLE
added table_to_taglist userdata / NUTAG_WITH support

### DIFF
--- a/src/nua/luasofia_nua.c
+++ b/src/nua/luasofia_nua.c
@@ -30,24 +30,18 @@
 #include "utils/luasofia_const.h"
 #include "utils/luasofia_log.h"
 #include "nua/luasofia_nua_handle.h"
+#include "nua/luasofia_nua.h"
 
 #include <sofia-sip/nua.h>
 #include <sofia-sip/nua_tag.h>
 #include <sofia-sip/soa_tag.h>
 #include <sofia-sip/su_tag_io.h>
 
-typedef struct luasofia_nua_s luasofia_nua_t;
-
-#define NUA_MTABLE              "luasofia_nua_t"
 
 #define NUA_EVENT_DEFAULT_INDEX -10
 
 #define ENV_CALLBACK_INDEX      1
 #define ENV_MAGIC_INDEX         2
-
-struct luasofia_nua_s {
-    nua_t *nua;
-};
 
 static int luasofia_nua_set_params(lua_State *L)
 {

--- a/src/nua/luasofia_nua.h
+++ b/src/nua/luasofia_nua.h
@@ -1,0 +1,33 @@
+/* vim: set ts=8 et sw=4 sta ai cin: */
+/*
+ * @author Paulo Pizarro  <paulo.pizarro@gmail.com>
+ * @author Tiago Katcipis <tiagokatcipis@gmail.com>
+ *
+ * This file is part of Luasofia.
+ *
+ * Luasofia is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Luasofia is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Luasofia.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __LUASOFIA_NUA_H__
+#define __LUASOFIA_NUA_H__
+
+struct luasofia_nua_s {
+    nua_t *nua;
+};
+typedef struct luasofia_nua_s luasofia_nua_t;
+
+#define NUA_MTABLE              "luasofia_nua_t"
+
+
+#endif /* __LUASOFIA_NUA_H__ */


### PR DESCRIPTION
To answer incoming register requests it is currently not possible to :respond().
Incoming REGISTER needs to be answered with current request, e.g.:

nh:respond(200,"OK",{ NUTAG_WITH=ua })

The table_to_taglist only tries to convert the given tagtable value into a string which of course fails. 

This patch checks if the value on the stack is of type userdata and if the tagname is nua.with (which is NUTAG_WHICH). REGISTER and other incoming requests can now be correctly answered.
